### PR TITLE
infra: fix bot default port

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -16,7 +16,7 @@ const bot = botBuilder.build(credentials)
 const connector = path(['connectors', '*'], bot)
 
 const server = restify.createServer()
-server.listen(process.env.PORT || 3987, () => {
+server.listen(process.env.PORT || 3000, () => {
   console.log('%s listening on %s', server.name, server.url)
 })
 


### PR DESCRIPTION
This commit just set `3000` as a default port. The port that was defined
generate a 502 error, so this commit just fix its problem.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)
Solve #5 

* **What is the new behavior (if this is a feature change)?**
Solve #5 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.