### PR TITLE
bot: define a storage method

### DIFF
--- a/app/botBuilder/buildBot.js
+++ b/app/botBuilder/buildBot.js
@@ -1,7 +1,12 @@
-import { UniversalBot } from 'botbuilder'
+import {
+  MemoryBotStorage,
+  UniversalBot,
+} from 'botbuilder'
+
+const inMemoryStorage = new MemoryBotStorage()
 
 const buildBot = connector => new UniversalBot(connector, (session) => {
   session.send('You said %s', session.message.text)
-})
+}).set('storage', inMemoryStorage)
 
 export default buildBot


### PR DESCRIPTION
The bot persist some data about users. This data is responsible for
identify the user and is used to define who will receive an asware, for
example, but default storage method was deprecated, so bot stop to answare.

To solve this problem, this commit set inMemoryStorage as a storage method.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What is the current behavior?** (You can also link to an open issue here)
The bot can't asware anything because its can't identify users to send message (can't persist connection data).

* **What is the new behavior (if this is a feature change)?**
The new storage method fix issue #10 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.